### PR TITLE
Change path names and filenames to work with Windows containers

### DIFF
--- a/apeer_dev_kit/_core.py
+++ b/apeer_dev_kit/_core.py
@@ -34,6 +34,10 @@ class _core:
             message = 'Input file {} not found'.format(self.wfe_input_file_name)
             log.error(message)
             raise IOError(message)
+        except AttributeError:
+            message = 'ADK not initialized'
+            log.error(message)
+            raise IOError(message)
 
     def _get_inputs(self):
         ''' Get the inputs'''

--- a/apeer_dev_kit/_core.py
+++ b/apeer_dev_kit/_core.py
@@ -6,7 +6,6 @@ from ._utility import copyfile
 
 class _core:
     WFE_INPUT_ENV_VARIABLE = 'WFE_INPUT_JSON'
-    WFE_INPUT_FILE_NAME = '/params/WFE_input_params.json'
 
     def __init__(self):
         log.basicConfig(format='%(asctime)s [ADK:%(levelname)s] %(message)s', level=log.INFO, datefmt='%Y-%m-%d %H:%M:%S')
@@ -15,6 +14,13 @@ class _core:
         self._wfe_output_params_file = ''
         self._input_json = self._read_inputs()
         log.info('Found module\'s inputs to be {}'.format(self._input_json))
+        if os.name == 'nt':
+            self.output_dir = 'C:\\output\\'
+            self.wfe_input_file_name = 'C:\\params\\WFE_input_params.json'
+        else:
+            self.output_dir = '/output/'
+            self.wfe_input_file_name = '/params/WFE_input_params.json'
+
 
     def _read_inputs(self):
         ''' Read inputs either from file or from environment variable'''
@@ -22,17 +28,17 @@ class _core:
             if self.WFE_INPUT_ENV_VARIABLE in os.environ:
                 return json.loads(os.environ[self.WFE_INPUT_ENV_VARIABLE])
             else:
-                with open(self.WFE_INPUT_FILE_NAME, 'r') as input_file:
+                with open(self.wfe_input_file_name, 'r') as input_file:
                     return json.load(input_file)
         except IOError:
-            message = 'Input file {} not found'.format(self.WFE_INPUT_FILE_NAME)
+            message = 'Input file {} not found'.format(self.wfe_input_file_name)
             log.error(message)
             raise IOError(message)
 
     def _get_inputs(self):
         ''' Get the inputs'''
         try:
-            self._wfe_output_params_file = '/output/' + self._input_json.pop('WFE_output_params_file')
+            self._wfe_output_params_file = self.output_dir + self._input_json.pop('WFE_output_params_file')
             log.info('Outputs will be written to {}'.format(self._wfe_output_params_file))
             return self._input_json
         except KeyError:
@@ -55,10 +61,10 @@ class _core:
                 if(not f or f.isspace()):
                     log.warn('Empty filepath, skipping')
                     continue
-                if(f.startswith('/output/')):
+                if(f.startswith(self.output_dir)):
                     dsts.append(f)
                 else:
-                    dst = '/output/' + os.path.basename(f)
+                    dst = self.output_dir + os.path.basename(f)
                     log.info('Copying file "{}" to "{}"'.format(os.path.basename(f), dst))
                     copyfile(f, dst)
                     dsts.append(dst)
@@ -68,10 +74,10 @@ class _core:
             if(not filepath or filepath.isspace()):
                 log.warn('Empty filepath, skipping')
                 return
-            if(filepath.startswith('/output/')):
+            if(filepath.startswith(self.output_dir)):
                 dst = filepath
             else:
-                dst = '/output/' + os.path.basename(filepath)
+                dst = self.output_dir + os.path.basename(filepath)
                 log.info('Copying file "{}" to "{}"'.format(os.path.basename(filepath), dst))
                 copyfile(filepath, dst)
             self._set_output(key, dst)

--- a/tests/tests_core.py
+++ b/tests/tests_core.py
@@ -8,6 +8,13 @@ from apeer_dev_kit import _core
 
 class TestsCore(unittest.TestCase):
 
+    def __init__(self, *args, **kwargs):
+        super(TestsCore, self).__init__(*args, **kwargs)
+        if os.name == 'nt':
+            self.output_dir = 'C:\\output\\'
+        else:
+            self.output_dir = '/output/'
+
     # __init__
     def test_init_givenNoEnvironmentVariableAndNoInputFile_coreIsNotInitialized(self):
         with self.assertRaises(IOError):
@@ -164,28 +171,28 @@ class TestsCore(unittest.TestCase):
 
         core._set_file_output("file", "file.txt")
 
-        mock_shutil.copyfile.assert_called_with("file.txt", "/output/file.txt")
-        self.assertEqual(core._outputs["file"], "/output/file.txt")
+        mock_shutil.copyfile.assert_called_with("file.txt", os.path.join(self.output_dir, "file.txt"))
+        self.assertEqual(core._outputs["file"], os.path.join(self.output_dir, "file.txt"))
 
     @mock.patch('apeer_dev_kit._utility.shutil')
     def test_set_file_output_givenFileInOutputFolder_FileNotCopied(self, mock_shutil):
         os.environ["WFE_INPUT_JSON"] = '{}'
         core = _core._core()
 
-        core._set_file_output("file", "/output/file.txt")
+        core._set_file_output("file", os.path.join(self.output_dir, "file.txt"))
 
         mock_shutil.copyfile.assert_not_called()
-        self.assertEqual(core._outputs["file"], "/output/file.txt")
+        self.assertEqual(core._outputs["file"], os.path.join(self.output_dir, "file.txt"))
 
     @mock.patch('apeer_dev_kit._utility.shutil')
     def test_set_file_output_givenFileListInOutputFolder_FileNotCopied(self, mock_shutil):
         os.environ["WFE_INPUT_JSON"] = '{}'
         core = _core._core()
 
-        core._set_file_output("file", ["/output/file1.txt", "/output/file2.txt"])
+        core._set_file_output("file", [os.path.join(self.output_dir, "file1.txt"), os.path.join(self.output_dir, "file2.txt")])
 
         mock_shutil.copyfile.assert_not_called()
-        self.assertEqual(core._outputs["file"], ["/output/file1.txt", "/output/file2.txt"])
+        self.assertEqual(core._outputs["file"], [os.path.join(self.output_dir, "file1.txt"), os.path.join(self.output_dir, "file2.txt")])
 
     @mock.patch('apeer_dev_kit._utility.shutil')
     def test_set_file_output_givenFileListNotInOutputFolder_FileCopied(self, mock_shutil):
@@ -195,9 +202,9 @@ class TestsCore(unittest.TestCase):
         core._set_file_output("file", ["file1.txt", "file2.txt"])
 
         mock_shutil.copyfile.assert_has_calls([
-            mock.call("file1.txt", "/output/file1.txt"),
-            mock.call("file2.txt", "/output/file2.txt")])
-        self.assertEqual(core._outputs["file"], ["/output/file1.txt", "/output/file2.txt"])
+            mock.call("file1.txt", os.path.join(self.output_dir, "file1.txt")),
+            mock.call("file2.txt", os.path.join(self.output_dir, "file2.txt"))])
+        self.assertEqual(core._outputs["file"], [os.path.join(self.output_dir, "file1.txt"), os.path.join(self.output_dir, "file2.txt")])
 
     def tearDown(self):
         if 'WFE_INPUT_JSON' in os.environ:


### PR DESCRIPTION
These modifications allow the ADK to work on Windows docker containers, too.  The output directory is changed from `\output` to `C:\output`, and the input directory is changed similarly.  The input parameters filepath is also modified to work on Windows.