### PR TITLE
change the self attribute declaration sequence

### DIFF
--- a/apeer_dev_kit/_core.py
+++ b/apeer_dev_kit/_core.py
@@ -12,15 +12,14 @@ class _core:
         log.info('Initializing')
         self._outputs = {}
         self._wfe_output_params_file = ''
-        self._input_json = self._read_inputs()
-        log.info('Found module\'s inputs to be {}'.format(self._input_json))
         if os.name == 'nt':
             self.output_dir = 'C:\\output\\'
             self.wfe_input_file_name = 'C:\\params\\WFE_input_params.json'
         else:
             self.output_dir = '/output/'
             self.wfe_input_file_name = '/params/WFE_input_params.json'
-
+        self._input_json = self._read_inputs()
+        log.info('Found module\'s inputs to be {}'.format(self._input_json))
 
     def _read_inputs(self):
         ''' Read inputs either from file or from environment variable'''


### PR DESCRIPTION
In order to resolve the following error:

============
2020-11-17 09:40:43 [ADK:INFO] Initializing
2020-11-17 09:40:43 [ADK:ERROR] ADK not initialized
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/apeer_dev_kit/_core.py", line 31, in _read_inputs
    with open(self.wfe_input_file_name, 'r') as input_file:
AttributeError: '_core' object has no attribute 'wfe_input_file_name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./apeer_main.py", line 1, in <module>
    ﻿from apeer_dev_kit import adk
  File "/usr/local/lib/python3.6/dist-packages/apeer_dev_kit/adk.py", line 3, in <module>
    _adk = _core._core()
  File "/usr/local/lib/python3.6/dist-packages/apeer_dev_kit/_core.py", line 15, in __init__
    self._input_json = self._read_inputs()
  File "/usr/local/lib/python3.6/dist-packages/apeer_dev_kit/_core.py", line 40, in _read_inputs
    raise IOError(message)
OSError: ADK not initialized